### PR TITLE
Reduce Flicker

### DIFF
--- a/Source/SynEdit.pas
+++ b/Source/SynEdit.pas
@@ -2155,7 +2155,7 @@ begin
           OffsetRect(rcInval, Left, Top);
 {$ENDIF}
         if sfLinesChanging in FStateFlags then
-          UnionRect(FInvalidateRect, FInvalidateRect, rcInval)
+          UnionRect(fInvalidateRect, rcInval, fInvalidateRect)
         else
           InvalidateRect(rcInval, False);
       end;
@@ -2391,7 +2391,6 @@ begin
   Exclude(FStateFlags, sfLinesChanging);
   if HandleAllocated then
   begin
-    UpdateScrollBars;
     vOldMode := FActiveSelectionMode;
     SetBlockBegin(CaretXY);
     FActiveSelectionMode := vOldMode;
@@ -5579,7 +5578,6 @@ begin
       if CallEnsureCursorPos then
         EnsureCursorPosVisible;
       Include(FStateFlags, sfCaretChanged);
-      Include(FStateFlags, sfScrollbarChanged);
     finally
       DecPaintLock;
     end;
@@ -7112,6 +7110,7 @@ begin
 
   InvalidateLines(aIndex + 1, MaxInt);
   InvalidateGutterLines(aIndex + 1, MaxInt);
+  Include(fStateFlags, sfScrollbarChanged);
 end;
 
 procedure TCustomSynEdit.ListInserted(Sender: TObject; Index: Integer;
@@ -7134,6 +7133,7 @@ begin
 
   InvalidateLines(Index + 1, MaxInt);
   InvalidateGutterLines(Index + 1, MaxInt);
+  Include(fStateFlags, sfScrollbarChanged);
 
   if (eoAutoSizeMaxScrollWidth in FOptions) then
   begin


### PR DESCRIPTION
Removed unnecessary invalidations
UpdateScrollbars calls Invalidate causing full repaint.
As it stands moving the cursor eg. left or rigth and typing one
character results in a full repaint and flicker.

Three changes were made that resolve the issue.
a) In SetCaretXYEx I removed the line
Include(fStateFlags, sfScrollbarChanged);
since it is not needed.  Scrollbars are updated when TopLine or LeftChar
get changed.
b)   I removed UpdateScrollbars for LinesChanged and added
Include(fStateFlags, sfScrollbarChanged);
to ListInserted, ListDeleted.  Thus when the user types code in one line
this does not result in a full repaint.
b) In LinesInserted I changed the line
UnionRect(fInvalidateRect, fInvalidateRect, rcInval)
to
UnionRect(fInvalidateRect, rcInval, fInvalidateRect)
This subtle change prevents the invalidate of the lines above the line
you are typing when fInvalidateRect is empty.