### PR TITLE
Fixed an issue where text ranges could not be selected with the mouse.

### DIFF
--- a/Source/SynEditScrollBars.pas
+++ b/Source/SynEditScrollBars.pas
@@ -334,6 +334,8 @@ begin
       ScrollInfo := GetBarScrollInfo(sbHorizontal);
       FOwner.LeftChar := ScrollInfo.nTrackPos;
       SetScrollBarPos(sbHorizontal, ScrollInfo.nTrackPos, False);
+      if AMsg.ScrollCode = SB_THUMBPOSITION then
+        FIsScrolling := False;
     end;
     SB_ENDSCROLL:
     begin
@@ -413,6 +415,8 @@ begin
           ScrollHint.Update;
         end;
         SetScrollBarPos(sbVertical, ScrollInfo.nTrackPos, False);
+        if AMsg.ScrollCode = SB_THUMBPOSITION then
+          FIsScrolling := False;
       end;
       // Ends scrolling
     SB_ENDSCROLL:


### PR DESCRIPTION
SB_ENDSCROLL is not sent when the lower word of wParam is SB_THUMBPOSITION in the WM_HSCROLL, WM_VSCROLL message.
For this reason, when scrolling was performed using SB_THUMBPOSITION (scroll function of some pointing devices), it was incorrectly determined that the scrolling was continuing, and a bug was fixed in which the text range could not be selected using the mouse.
(Just to be safe, FIsScrolling is set to True while scrolling is being processed.)
